### PR TITLE
feat: add alarms to express future time intent

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -21,32 +21,56 @@ type Clock interface {
 	// NewTimer creates a new Timer that will send the current time
 	// on its channel after at least duration d.
 	NewTimer(d time.Duration) Timer
+
+	// At waits for the time to pass and then sends the
+	// current time on the returned channel.
+	At(t time.Time) <-chan time.Time
+
+	// AtFunc waits for the time to pass and then calls f in its own goroutine.
+	// It returns an Alarm that can be used to cancel the call using its Stop method.
+	AtFunc(t time.Time, f func()) Alarm
+
+	// NewAlarm creates a new Alarm that will send the current time
+	// on its channel at or after time t has passed.
+	NewAlarm(t time.Time) Alarm
 }
 
-// Alarm returns a channel that will have the time sent on it at some point
-// after the supplied time occurs.
-//
-// This is short for c.After(t.Sub(c.Now())).
-func Alarm(c Clock, t time.Time) <-chan time.Time {
-	return c.After(t.Sub(c.Now()))
-}
-
-// The Timer type represents a single event.
-// A Timer must be created with AfterFunc.
+// Timer type represents a single event.
+// Timers must be created with AfterFunc or NewTimer.
 // This interface follows time.Timer's methods but provides easier mocking.
 type Timer interface {
-	// When the Timer expires, the current time will be sent on the
-	// channel returned from Chan, unless the Timer was created by
+	// When the timer expires, the current time will be sent on the
+	// channel returned from Chan, unless the timer was created by
 	// AfterFunc.
 	Chan() <-chan time.Time
 
 	// Reset changes the timer to expire after duration d.
 	// It returns true if the timer had been active, false if
 	// the timer had expired or been stopped.
-	Reset(time.Duration) bool
+	Reset(d time.Duration) bool
 
 	// Stop prevents the Timer from firing. It returns true if
 	// the call stops the timer, false if the timer has already expired or been stopped.
+	// Stop does not close the channel, to prevent a read
+	// from the channel succeeding incorrectly.
+	Stop() bool
+}
+
+// Alarm type represents a single event.
+// Alarms must be created with AtFunc or NewAlarm.
+type Alarm interface {
+	// When the alarm expires, the current time will be sent on the
+	// channel returned from Chan, unless the alarm was created by
+	// AtFunc.
+	Chan() <-chan time.Time
+
+	// Reset changes the alarm to expire at or after time t.
+	// It returns true if the alarm had been active, false if
+	// the alarm had fired or been stopped.
+	Reset(t time.Time) bool
+
+	// Stop prevents the alarm from firing. It returns true if
+	// the call stops the alarm, false if the alarm has already fired or been stopped.
 	// Stop does not close the channel, to prevent a read
 	// from the channel succeeding incorrectly.
 	Stop() bool

--- a/wall.go
+++ b/wall.go
@@ -45,3 +45,33 @@ type wallTimer struct {
 func (t wallTimer) Chan() <-chan time.Time {
 	return t.C
 }
+
+// At implements Clock.At.
+func (wallClock) At(t time.Time) <-chan time.Time {
+	return time.After(time.Until(t))
+}
+
+// AtFunc implements Clock.AtFunc.
+func (wallClock) AtFunc(t time.Time, f func()) Alarm {
+	return wallAlarm{time.AfterFunc(time.Until(t), f)}
+}
+
+// NewAlarm implements Clock.NewAlarm.
+func (wallClock) NewAlarm(t time.Time) Alarm {
+	return wallAlarm{time.NewTimer(time.Until(t))}
+}
+
+// wallAlarm implements the Alarm interface.
+type wallAlarm struct {
+	*time.Timer
+}
+
+// Chan implements Alarm.Chan.
+func (a wallAlarm) Chan() <-chan time.Time {
+	return a.C
+}
+
+// Reset implements Alarm.Reset
+func (a wallAlarm) Reset(t time.Time) bool {
+	return a.Timer.Reset(time.Until(t))
+}


### PR DESCRIPTION
This expands on the concept of Alarms. Purely this helps only testing code.

Alarms are set to go off at or after a point in the future, rather than after an elapsed time duration.
This is useful for code to express the intent of its use of a time/alarm mechanism.

If a worker wants to wait a duration of time, it can do this by expressing a duration timer.
If a worker wants to wait until a point in time, it can do this by expressing a time alarm.

The distinction between the two is important when testing workers that deal with scheduled events rather than delayed events. An example is an expiration worker, it knows that a certificate will expire at a certain time in the future, so it schedules a timer for the delta between now and that time. With a wall clock, there is no difference between a timer and an alarm.

With testing clocks, they can move the Now point forward fast (cpu cycles fast), such that the point in time calculated is wrong:
With timers:
```
0s                                  1s                                  2s
x=clock.Now().Add(time.Second)
      d=x.Sub(clock.Now())        a=clock.After(d)             <-a.Chan()
                          ^clock.Advance(time.Second)
```

With alarms:
```
0s                                                                      1s
      t=clock.Now().Add(time.Second)        a=clock.At(t)      <-a.Chan()
                   ^clock.Advance(time.Second)
```

With both examples, the intent is to trigger the event at a specified time, calculation here is merely demonstration.