### PR TITLE
fix: testclock.Clock alarm at now without advance

### DIFF
--- a/testclock/clock.go
+++ b/testclock/clock.go
@@ -277,7 +277,7 @@ func (clock *Clock) resetTime(t *timer, deadline time.Time) bool {
 	}
 	t.deadline = deadline
 	sort.Sort(byDeadline(clock.waiting))
-	if clock.now.After(t.deadline) {
+	if !clock.now.Before(t.deadline) {
 		// If the time has already passed, that means we should be triggering the
 		// Timer right away, as "now" has already occurred.
 		clock.triggerAll()

--- a/testclock/clock_test.go
+++ b/testclock/clock_test.go
@@ -425,3 +425,14 @@ func (*clockSuite) TestPastAlarmFired(c *gc.C) {
 		c.Fatal("alarm did not fire by deadline")
 	}
 }
+
+func (*clockSuite) TestNowAlarmFired(c *gc.C) {
+	t0 := time.Now()
+	cl := testclock.NewClock(t0)
+	alarm := cl.NewAlarm(cl.Now())
+	select {
+	case <-alarm.Chan():
+	case <-time.After(testing.ShortWait):
+		c.Fatal("alarm did not fire by deadline")
+	}
+}


### PR DESCRIPTION
Alarms added for now to a testclock.Clock must fire. Not a problem with wall clocks or dilated wall clocks, since they are auto advancing.